### PR TITLE
Add gen8x to Colors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [CSS Gradient Generator](https://optimize-overseas.github.io/autonomousbot/tools/css-gradient.html) - Create beautiful CSS gradients with a visual editor. Copy CSS code instantly.
 - [Gradient Forge](https://ryudi84.github.io/sovereign-tools/tools/gradient_forge/) - Create CSS gradients with a visual editor and code output. Free, no signup required.
 - [Contrast Checker](https://optimize-overseas.github.io/autonomousbot/tools/contrast-checker.html) - Check WCAG color contrast ratios for accessibility compliance. Test foreground/background combinations.
+- [gen8x](https://gen8x.com/) - Generate harmonious color palettes with WCAG contrast checks and export as CSS variables, Tailwind config, SCSS, or JSON. Free, client-side, no signup.
 
 ## Designs
 


### PR DESCRIPTION
## What this PR adds

Adds **gen8x** ([https://gen8x.com/](https://gen8x.com/)) to the **Colors** section.

gen8x is a free, client-side color palette generator that:

- Generates harmonious palettes from a base color (complementary, analogous, triadic, tetradic, split-complementary, and monochromatic schemes)
- Runs **WCAG AA/AAA contrast checks** between every color pair in the palette
- Exports to CSS custom properties, Tailwind config, SCSS variables, or JSON
- Works entirely in the browser — nothing is sent to a server, no signup

## Why it fits

The Colors section already includes palette/gradient generators (Palettte App, Flat UI Colors, InclusiveColors, Color Forge). gen8x complements these by pairing palette generation with accessibility-first contrast verification, so designers can confirm their palette meets WCAG contrast ratios before exporting.

## Disclosure

I am the maintainer of gen8x.

## Verification

- Link returns HTTP 200
- Tool runs fully client-side, no signup, no paywall
- Format matches the list convention: `- [Name](URL) - Description.`