### PR TITLE
Add TinyTools to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@
 - [Pixelate Image](https://www.pixelateimage.co/) - Pixelate Your Images Instantly
 - [ToolSparkr](https://toolsparkr.com) - Collection of 35+ free online developer tools — JSON formatter, URL encoder, password generator, Base64 encoder, hash generators, QR code generator, DNS lookup, and more. No signup, runs in browser.
 - [BulkPicTools](https://bulkpictools.com/) - Free browser-based bulk image processor. Compress, convert (HEIC/WebP/AVIF/PNG/JPG), resize, and crop 1,000+ images at once — no upload, no account needed.
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based web utilities including domain name generator, OG image generator, AI background remover (runs locally), favicon generator, color palette generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator, and AI robots.txt generator. No signup, open source.
 
 ## learning
 


### PR DESCRIPTION
Adds [TinyTools](https://tinytools-smoky.vercel.app/) — a free, open-source collection of 9 single-purpose, browser-based web utilities — to the Utils section.

Included tools:

- Domain name generator
- OG image generator
- AI background remover (runs locally)
- Favicon generator
- Color palette generator
- SEO meta tag generator
- AI cost calculator
- AI content disclosure generator (EU AI Act compliant)
- AI robots.txt generator

All tools are 100% client-side (no uploads, no signup) and run in the browser. The project is MIT-licensed and open source.

Fits the same niche as existing entries like NexTool, ToolSparkr, BeginThings, and DevTools in the Utils section.