### PR TITLE
Add ShotFrame screenshot beautifier and 万能工具箱 online toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@
 - [CSS loader generator](https://www.cssportal.com/css-loader-generator/) - Generate the perfect loader with our online collection of spinners and loaders for CSS, currently 310 to select from.
 
 ## Utils
+- [ShotFrame](https://tyr1105.github.io/shotframe/) - Free screenshot beautifier with customizable backgrounds, padding, and borders. 100% browser-side, no registration, no watermarks. Open source.
+- [万能工具箱 (Universal Toolbox)](https://tyr1105.github.io/) - 42+ free online tools for developers and designers (JSON formatter, image compression, QR code generator, and more). 100% browser-side, no registration, open source.
 - [Remove Audio](https://remove-audio.com) - Free browser-based tool to strip audio from video files. Runs locally via WebAssembly, no uploads, no sign-up, batch up to 20 clips.
 
 - [BeginThings](https://beginthings.com) - 96+ free browser-based tools for freelancers: invoice generator, time tracker, Pomodoro timer, QR code maker, URL shortener, UTM builder, rate calculator, and more. No signup required.


### PR DESCRIPTION
Hi! I'd like to add two free, open-source, browser-side tools to the Utils section:

## ShotFrame
- **URL**: https://tyr1105.github.io/shotframe/
- **GitHub**: https://github.com/tyr1105/shotframe
- **Description**: Free screenshot beautifier with customizable backgrounds, padding, and borders. Perfect for creating beautiful code screenshots and sharing images. 100% browser-side, no registration, no watermarks.

## 万能工具箱 (Universal Toolbox)
- **URL**: https://tyr1105.github.io/
- **Description**: 42+ free online tools for developers and designers (JSON formatter, image compression, QR code generator, Base64 encoder, and more). 100% browser-side, no registration, open source.

Both tools fit well alongside the other browser-based utilities already listed in the Utils section. Thanks for maintaining this list! 🙏