### PR TITLE
Add App Doodler to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 ## Utils
 
 - [Am I Responsive](https://ui.dev/amiresponsive) - Preview responsive design across four viewport sizes at once.
+- [App Doodler](https://doodler.copymyui.com/) - Create multilingual App Store screenshots from reusable layouts and translation files.
 - [Base64 Encoder/Decoder](https://optimize-overseas.github.io/autonomousbot/tools/base64.html) - Encode and decode Base64 strings client-side.
 - [Base64 Image](https://www.base64-image.de/) - Convert images to Base64 for use in HTML and CSS.
 - [BeginThings](https://beginthings.com) - 96+ free browser-based tools for freelancers including invoicing, time tracking, and QR codes.


### PR DESCRIPTION
Adds App Doodler to the Utils section.

Project URL: https://doodler.copymyui.com/
Source code: https://github.com/IgorShadurin/app-doodler
License: Apache-2.0

App Doodler is a free, open-source browser tool for creating multilingual App Store screenshots from reusable layouts and translation files.

Disclosure: I maintain App Doodler.
