### PR TITLE
Add Toolio to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [TinyTools](https://tinytools-smoky.vercel.app/) - Domain generator, OG image maker, favicon generator, and other browser-based utilities.
 - [ToolArks](https://toolarks.com) - Privacy-first toolbox with image compression and JSON formatting — 100% local.
 - [ToolBox](https://www.toolbox-kit.com) - 170+ client-side tools for developers and designers.
+- [Toolio](https://toolio.pongvn.com) - 195 free browser tools including PDF, image, converter, and developer utilities — most run client-side with no upload.
 - [ToolSparkr](https://toolsparkr.com) - 35+ developer tools including JSON formatter, hash generators, and DNS lookup.
 - [Unix Timestamp Converter](https://optimize-overseas.github.io/autonomousbot/tools/unix-timestamp.html) - Convert between Unix timestamps and human-readable dates.
 - [Unused CSS](https://unused-css.com/) - Find and remove unused CSS rules from your stylesheets.


### PR DESCRIPTION
Adds [Toolio](https://toolio.pongvn.com) to the **Utils** section.

Toolio is a free, no-signup collection of 195 browser tools — PDF, image, converters, calculators, and developer utilities. Most of them run entirely client-side, so files never leave the browser.

- Placed in `Utils` alphabetically (between ToolBox and ToolSparkr), following the existing `- [Name](url) - Description.` format.
- Full disclosure: I'm the maker. Per CONTRIBUTING, self-submissions are fine as long as they fit — happy to adjust the wording, section, or drop it if you'd rather not have it.

Thanks for maintaining the list!