### PR TITLE
Add UIZZE design resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [UI Faces](https://uifaces.co/) - Sample profile avatars for mockups and prototypes.
 - [UI Store Design](https://www.uistore.design/) - 650+ free handpicked UI kits for real projects.
 - [UI8](https://ui8.net/) - Curated design resources to speed up creative workflows.
+- [UIZZE](https://uizze.com/) - Public catalog of real web and iOS product UI references; full access adds hosted MCP workflows for coding-agent design contracts, validation, audits, and critiques.
 - [XD Guru](https://www.xdguru.com/) - Adobe XD resources, UI kits, and templates.
 
 ## Shape makers


### PR DESCRIPTION
## What changed

Adds UIZZE to the **Designs** section.

## Why

UIZZE is a design-reference resource: its public catalog provides real web and iOS product UI references, and full access adds hosted MCP workflows for coding-agent design contracts, validation, audits, and critiques.

## Validation

- Confirmed the entry uses the official URL.
- Confirmed placement and alphabetical ordering in the Designs section.
