### PR TITLE
Add File Size Converter to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [DevTools](https://devtools.davrapps.dev) - 16 free browser-based tools: JSON formatter, JWT decoder, regex tester, cron builder, and more.
 - [Down for Everyone or Just Me](https://downforeveryoneorjustme.com/) - Check if a website is down globally or only for you.
 - [EncodingBase64](https://encodingbase64.com/) - Base64 encoding and decoding for text, files, images, and URL-safe formats.
+- [File Size Converter](https://nutilz.com/file-size-converter) - Convert between bytes, KB, MB, GB, and TB, supporting both decimal (SI) and binary (IEC) units.
 - [Gitignore Generator](https://www.toptal.com/developers/gitignore) - Generate `.gitignore` files for any project type.
 - [Haikei](https://app.haikei.app/) - Generate unique SVG design assets.
 - [Hash Generator](https://optimize-overseas.github.io/autonomousbot/tools/hash-generator.html) - Generate MD5, SHA-1, SHA-256, and SHA-512 hashes client-side.


### PR DESCRIPTION
Adds Nutilz File Size Converter (https://nutilz.com/file-size-converter), a free browser-based tool for converting between bytes, KB, MB, GB, and TB with both decimal (SI) and binary (IEC) unit support. Placed alphabetically in the Utils section.