### PR TITLE
Add Nutilz Clip-path Generator to Shape makers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Animated Backgrounds](https://animatedbackgrounds.me/) - Collection of animated CSS backgrounds.
 - [Blobmaker](https://www.blobmaker.app/) - Generate organic blob shapes for designs.
 - [Box Shadow Generator](https://dailytoolkit.app/tools/css-box-shadow-generator) - Visually build layered CSS box-shadows and export the code
+- [Clip-path Generator](https://nutilz.com/clip-path-generator) - Drag handles on a live preview to build CSS `clip-path` polygons, with 10 preset shapes and instant CSS output.
 - [Clippy](https://bennettfeely.com/clippy/) - CSS `clip-path` shape maker.
 - [CSS Filters](https://www.cssfilters.co/) - Visual playground for custom and Instagram-like CSS photo filters.
 - [CSS Glow Generator](https://cssbud.com/css-generator/css-glow-generator/) - Generate CSS glow and shadow effects.


### PR DESCRIPTION
Adds [Nutilz Clip-path Generator](https://nutilz.com/clip-path-generator) to the Shape makers section, alongside Clippy. It's a free, browser-based visual editor for CSS `clip-path` polygons — drag handles on a live preview, choose from 10 preset shapes (triangle, pentagon, hexagon, star, arrow, etc.) or build a custom polygon, and copy production-ready CSS instantly. No signup required.