### PR TITLE
Add GPT Image 2 to AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 ## AI
 
 - [DeepSeek Chat](https://chat.deepseek.com/) - AI chat assistant for coding and general questions.
+- [GPT Image 2](https://gptimage2.asia/) - AI image generator and editor for marketing, ecommerce, social media, and branded visuals.
 - [Hotpot.ai](https://hotpot.ai/) - AI image editor, generator, and writing tools.
 - [igly.ai](https://igly.ai) - AI image editor for background removal, inpainting, upscaling, and generative fill.
 - [Image Translate AI](https://imagetranslateai.org/) - Translate text in images across 200+ languages while preserving layout.


### PR DESCRIPTION
Adds GPT Image 2 to the AI section.

It fits the existing AI image/design tools category and uses the required single-line format with the official URL.

Disclosure: submitted by the project owner/operator.