### PR TITLE
Add Olivez Hash Generator & Checksum Checker to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Lorem Ipsum Generator](https://dailytoolkit.app/tools/lorem-ipsum-generator) - Generate placeholder text in custom lengths for mockups and layouts.
 - [NexTool](https://nextool.app/free-tools/) - 228+ client-side developer tools including CSS generators, color tools, and formatters.
 - [Nutilz](https://nutilz.com) - Free browser-based calculators, text, image, and developer tools — no signup required.
+- [Olivez Hash Generator & Checksum Checker](https://olivez.in/tool/hash-generator-checker) - Generate SHA-256, SHA-384, or SHA-512 for text and files, then verify raw digests, GNU or BSD checksum lines, and checksum lists locally.
 - [OneLang](https://ide.onelang.io/) - Convert code between programming languages.
 - [Password Generator](https://dailytoolkit.app/tools/password-generator) - Generate strong, random passwords with customizable length and character sets.
 - [Pixelate Image](https://www.pixelateimage.co/) - Pixelate images instantly in the browser.


### PR DESCRIPTION
Adds Olivez Hash Generator & Checksum Checker to the Utils section in alphabetical order.

The tool generates SHA-256, SHA-384, and SHA-512 digests for text or local files. It can also verify raw hashes, GNU and BSD checksum lines, labelled digests, and multiline checksum lists while detecting filename and algorithm mismatches.