### PR TITLE
Add Nutilz CSS Animation Generator to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Can I Email](https://www.caniemail.com/) - Support tables for HTML and CSS in email clients.
 - [Can I Use](https://caniuse.com/) - Up-to-date browser support tables for front-end web technologies.
 - [Cleanmock](https://cleanmock.com/) - Create beautiful website and design mockups.
+- [CSS Animation Generator](https://nutilz.com/css-animation-generator) - Visually build CSS keyframe animations and get the ready-to-use CSS, no signup required.
 - [CSS Ruler](https://katydecorah.com/css-ruler/) - Explore and compare CSS length units.
 - [CSS Toolkit](https://csstoolkit.net) - Box shadow, border radius, px-to-rem, text shadow, and animation generators.
 - [CSS Tools Online](https://codebeautify.org/css-tools) - Collection of CSS utilities for common developer tasks.


### PR DESCRIPTION
Adds [CSS Animation Generator](https://nutilz.com/css-animation-generator), a free browser-based tool for visually building CSS `@keyframes` animations (with presets, timing-function controls, and CSS/Tailwind export). Runs entirely client-side, no signup required. Placed alphabetically in the Utils section, next to the other CSS generator tools.