### PR TITLE
Add AISO Tools Audit to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 
 ## AI
 
+- [AISO Tools Audit](https://aisotools.com/audit) - Check whether ChatGPT recommends your tool in its category by running five buying-intent prompts and scoring the mentions.
 - [DeepSeek Chat](https://chat.deepseek.com/) - AI chat assistant for coding and general questions.
 - [Hotpot.ai](https://hotpot.ai/) - AI image editor, generator, and writing tools.
 - [igly.ai](https://igly.ai) - AI image editor for background removal, inpainting, upscaling, and generative fill.


### PR DESCRIPTION
Adds **[AISO Tools Audit](https://aisotools.com/audit)** to the **AI** section.

**What it does:** you enter a tool name and its category; it runs five buying-intent prompts through an LLM and returns a 0–100 visibility score, how many of the five prompts mentioned you, and which competitors got named instead. Free, no signup.

**Why AI and not Utils:** it sits next to `Seona AI` and `WebCoreLab` — WebCoreLab already covers GEO/AEO *page* visibility, and this is the category-level counterpart (are you in the recommendation set at all), so it complements rather than duplicates it.

**Per CONTRIBUTING:**
- One entry, `- [Name](url) - Description.` format, in the AI section.
- Placed first in the section to keep it alphabetical.
- Official URL, no shortener or affiliate params; verified `200` before submitting.
- Searched the README — not already listed.

Disclosure: I maintain the site. Happy to reword the description or drop it if it's not a fit.