### PR TITLE
Add JSON Tools to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [ImgTools](https://imgtools.davrapps.dev) - Compress, resize, crop, convert, watermark, and remove backgrounds from images.
 - [JSON Crack](https://jsoncrack.com/editor) - Visualize and explore JSON data.
 - [JSON Formatter](https://dailytoolkit.app/tools/json-formatter) - Format, validate, and beautify JSON with syntax highlighting.
+- [JSON Tools](https://www.pdfmavericks.com/json-tools) - Format, validate, and minify JSON, and convert it to CSV or XML, all client-side.
 - [JWT Decoder](https://dailytoolkit.app/tools/jwt-decoder) - Decode and inspect JSON Web Tokens directly in the browser.
 - [JWT Generator](https://dailytoolkit.app/tools/jwt-generator) - Create signed JSON Web Tokens for testing and development.
 - [Keycode Info](https://www.toptal.com/developers/keycode) - Press any key to get its JavaScript key code and KeyboardEvent details.


### PR DESCRIPTION
Adds [JSON Tools](https://www.pdfmavericks.com/json-tools) to Utils, placed alphabetically between JSON Formatter and JWT Decoder.

Formats, validates, and minifies JSON, and converts between JSON, CSV, and XML. Everything runs in the browser — no upload, no account, no server round-trip. Part of pdfmavericks.com, a browser-local toolkit.

Happy to adjust the entry text or section.