### PR TITLE
Add Mydentify JavaScript SEO Render Checker to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Keycode Info](https://www.toptal.com/developers/keycode) - Press any key to get its JavaScript key code and KeyboardEvent details.
 - [KeyboardTester.click Online Ruler](https://keyboardtester.click/online-ruler.php) - Browser ruler for measuring on-screen elements after calibration.
 - [Lorem Ipsum Generator](https://dailytoolkit.app/tools/lorem-ipsum-generator) - Generate placeholder text in custom lengths for mockups and layouts.
+- [Mydentify JavaScript SEO Render Checker](https://mydentify.com/tools/javascript-seo-render-checker) - Compare a page's initial HTML with its browser-rendered title, description, H1, canonical URL, structured data, links, and core text.
 - [NexTool](https://nextool.app/free-tools/) - 228+ client-side developer tools including CSS generators, color tools, and formatters.
 - [Nutilz](https://nutilz.com) - Free browser-based calculators, text, image, and developer tools — no signup required.
 - [OneLang](https://ide.onelang.io/) - Convert code between programming languages.


### PR DESCRIPTION
Adds one tool to the `Utils` section in alphabetical order.

The checker compares a page's initial server HTML with its browser-rendered title, description, H1, canonical URL, structured data, links, and core text. The linked route is public, free to use, and requires no signup.

The entry follows the repository's name-link-description format, uses the official canonical URL, and is not currently duplicated in the README.

Disclosure: I maintain Mydentify and the submitted tool.