### PR TITLE
Add Strong Password Generator to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Regex Tester](https://optimize-overseas.github.io/autonomousbot/tools/regex-tester.html) - Test and debug regular expressions with match highlighting.
 - [Remove Audio](https://remove-audio.com) - Strip audio from video files locally via WebAssembly — no uploads.
 - [Slug Generator](https://optimize-overseas.github.io/autonomousbot/tools/slug-generator.html) - Convert text to SEO-friendly URL slugs.
+- [Strong Password Generator](https://www.strong-password.com/) - Generate passwords, passphrases, PINs, and Wi-Fi QR codes client-side, with an embeddable widget.
 - [SVG to JSX](https://svg2jsx.com/) - Convert SVG markup to JSX for React apps.
 - [Text Diff Tool](https://optimize-overseas.github.io/autonomousbot/tools/text-diff.html) - Compare two texts with line-by-line diff highlighting.
 - [TextFaker](https://textfaker.com/) - Create realistic text message screenshots and browser-based content-prep assets for demos and mockups.


### PR DESCRIPTION
Adds [Strong Password Generator](https://www.strong-password.com/) to the Utils section, alphabetically between Slug Generator and SVG to JSX.

It generates passwords entirely in the browser (crypto.getRandomValues — nothing transmitted or stored) and goes beyond the generic generator already listed: passphrases, PINs, Wi-Fi keys with QR codes, bulk TXT/CSV/JSON export, a strength checker with real entropy numbers, and a free embeddable widget for any site. Free, no signup, no ads.

Per the contributing guidelines: one tool in this PR, and disclosing that it's my own project — I built and maintain it.