### PR TITLE
Add DeerImage to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [CSS Ruler](https://katydecorah.com/css-ruler/) - Explore and compare CSS length units.
 - [CSS Toolkit](https://csstoolkit.net) - Box shadow, border radius, px-to-rem, text shadow, and animation generators.
 - [CSS Tools Online](https://codebeautify.org/css-tools) - Collection of CSS utilities for common developer tasks.
+- [DeerImage](https://deerimage.com/) - Free no-sign-up browser image tools for compression, conversion, resizing, and editing.
 - [DevTools](https://devtools.davrapps.dev) - 16 free browser-based tools: JSON formatter, JWT decoder, regex tester, cron builder, and more.
 - [Down for Everyone or Just Me](https://downforeveryoneorjustme.com/) - Check if a website is down globally or only for you.
 - [EncodingBase64](https://encodingbase64.com/) - Base64 encoding and decoding for text, files, images, and URL-safe formats.


### PR DESCRIPTION
## Summary

- Add DeerImage to the Utils section
- Describe its free, no-sign-up browser image tools

DeerImage fits the Utils category as a general-purpose image toolkit for web designers and developers.

## Validation

- Kept the section in alphabetical order
- Confirmed the diff only adds one README entry
