### PR TITLE
Add ArtboardLab to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [All Tools Verse](https://alltoolsverse.com/) - 1,000+ free browser-based utilities for developers and designers, including code, data, text, image, document, and conversion tools. No signup required.
 - [Am I Responsive](https://ui.dev/amiresponsive) - Preview responsive design across four viewport sizes at once.
 - [App Doodler](https://doodler.copymyui.com/) - Create multilingual App Store screenshots from reusable layouts and translation files.
+- [ArtboardLab](https://artboardlab.com) - Open Adobe Illustrator .ai files in the browser and export them to SVG, PNG, or PDF without uploading them.
 - [Base64 Encoder/Decoder](https://optimize-overseas.github.io/autonomousbot/tools/base64.html) - Encode and decode Base64 strings client-side.
 - [Base64 Image](https://www.base64-image.de/) - Convert images to Base64 for use in HTML and CSS.
 - [BeginThings](https://beginthings.com) - 96+ free browser-based tools for freelancers including invoicing, time tracking, and QR codes.


### PR DESCRIPTION
Adds one entry to the `Utils` section, alphabetically between App Doodler and Base64 Encoder/Decoder. Single-line diff, nothing else changed.

```
- [ArtboardLab](https://artboardlab.com) - Open Adobe Illustrator .ai files in the browser and export them to SVG, PNG, or PDF without uploading them.
```

**Disclosure: I built ArtboardLab, so this is a self-submission.**

**What it does** — it opens Adobe Illustrator `.ai` files (the Illustrator file extension, not generative AI) and exports them to SVG, PNG, or PDF, with a viewer for inspecting the file first. Parsing runs on pdf.js in the browser, so the file is never sent to a server. Free, no account.

**Gap it fills** — I searched the README before submitting: `grep -in "illustrator" README.md` and `grep -in "artboard" README.md` both return nothing. The only `.ai` mentions are stock-asset sites that offer `.ai` downloads (PNG Tree, Iconfinder); nothing in the list opens or converts an Illustrator file. Designers hand off `.ai` files and the web side needs SVG or PNG, which usually means opening Illustrator.

The site also has image and calculator tools, but the Utils section already covers those well, so I've kept the entry to the Illustrator angle only.
