### PR TITLE
Add Codex Theme Builder to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Can I Email](https://www.caniemail.com/) - Support tables for HTML and CSS in email clients.
 - [Can I Use](https://caniuse.com/) - Up-to-date browser support tables for front-end web technologies.
 - [Cleanmock](https://cleanmock.com/) - Create beautiful website and design mockups.
+- [Codex Theme Builder](https://codextheme.tools) - Free browser theme builder for OpenAI Codex with live preview and CSS token export.
 - [Compify](https://compify.app/) - Open-source React component workflow.
 - [CSS Ruler](https://katydecorah.com/css-ruler/) - Explore and compare CSS length units.
 - [CSS Toolkit](https://csstoolkit.net) - Box shadow, border radius, px-to-rem, text shadow, and animation generators.


### PR DESCRIPTION
Adds [Codex Theme Builder](https://codextheme.tools) under **Utils** (alphabetical, after Cleanmock).

It is a free, no-signup browser theme builder for OpenAI Codex with live preview and CSS token export. Fits designer/developer utilities.