### PR TITLE
Add Image Machine to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Hash Generator](https://optimize-overseas.github.io/autonomousbot/tools/hash-generator.html) - Generate MD5, SHA-1, SHA-256, and SHA-512 hashes client-side.
 - [Hidden Tools](https://hiddentools-eight.vercel.app/) - Curated collection of unique online tools.
 - [Image Landscape Converter](https://image-landscape-converter.vercel.app/) - Rotate portrait photos to landscape orientation in the browser.
+- [Image Machine](https://imagemachinery.net) - Resize, crop, compress, convert, watermark, and OCR images entirely in the browser, with no upload.
 - [ImgTools](https://imgtools.davrapps.dev) - Compress, resize, crop, convert, watermark, and remove backgrounds from images.
 - [JSON Crack](https://jsoncrack.com/editor) - Visualize and explore JSON data.
 - [JSON Formatter](https://dailytoolkit.app/tools/json-formatter) - Format, validate, and beautify JSON with syntax highlighting.


### PR DESCRIPTION
Adds Image Machine to **Utils**.

A browser-side image toolkit: resize, crop, compress, convert between formats, watermark, and OCR. Everything runs client-side, so files are never uploaded - the JPEG XL and AVIF paths use libjxl/libaom compiled to WebAssembly, and OCR uses tesseract.js.

Sits alongside the existing ImgTools and BulkPicTools entries in the same category.

- [x] Alphabetical placement (after Image Landscape Converter, before ImgTools)
- [x] Format: `- [Tool Name](url) - description.`
- [x] One sentence, no marketing copy
- [x] Direct official URL, no shortener or affiliate link
- [x] Checked for duplicates
