### PR TITLE
Add ColorOf toolkit to Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Color Palette Earth](https://colorpalettes.earth/) - Daily color palette inspiration from nature.
 - [Color Picker](https://optimize-overseas.github.io/autonomousbot/tools/color-picker.html) - Free online color picker with HEX, RGB, and HSL conversion.
 - [Color Slurp](https://colorslurp.com/) - Pick, edit, and copy colors with a color picker for Mac and iOS.
+- [ColorOf](https://colorof.app/) - Color guide for palettes with comparison and accessibility checks.
 - [ColorTools](https://colorpicker.cx/color-picker) - Free browser-based image color picker with a color wheel, palette generator, CSS gradient builder, color converter, and WCAG contrast checker.
 - [Contrast Checker](https://optimize-overseas.github.io/autonomousbot/tools/contrast-checker.html) - Check WCAG color contrast ratios for accessibility compliance.
 - [CSS Gradient](https://cssgradient.io/) - Create colorful gradient backgrounds for websites, blogs, and social profiles.


### PR DESCRIPTION
Adds ColorOf to the Colors section.

ColorOf is a color guide for palettes with comparison and accessibility checks.

Link: https://colorof.app/