### PR TITLE
Add A Box of Tools to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 
 ## Utils
 
+- [A Box of Tools](https://abox.tools/) - 35 single-purpose file tools for images, video, audio, PDFs and text that run entirely in the browser, with nothing uploaded.
 - [All Tools Verse](https://alltoolsverse.com/) - 1,000+ free browser-based utilities for developers and designers, including code, data, text, image, document, and conversion tools. No signup required.
 - [Am I Responsive](https://ui.dev/amiresponsive) - Preview responsive design across four viewport sizes at once.
 - [App Doodler](https://doodler.copymyui.com/) - Create multilingual App Store screenshots from reusable layouts and translation files.


### PR DESCRIPTION
https://abox.tools/

35 single-purpose file tools that run entirely in the browser. The ones this
list's readers will use: compress an image to an exact KB budget, resize,
convert HEIC or SVG, image to a data URI for CSS, PNG or SVG to a real
multi-size `.ico`, favicon and app-icon sets, format JSON, diff text, base64.

Per the contributing guide:

- **Utils** is the fitting section — it already holds the other multi-tool
  browser sites
- alphabetically first in it, ahead of All Tools Verse
- official URL, no shortener or affiliate link
- one sentence, no marketing copy
- searched the README; not a duplicate

Free and open source (MIT): https://github.com/A-Box-of-Tools/website

🤖 Generated with [Claude Code](https://claude.com/claude-code)
