### PR TITLE
Add Ibis to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Haikei](https://app.haikei.app/) - Generate unique SVG design assets.
 - [Hash Generator](https://optimize-overseas.github.io/autonomousbot/tools/hash-generator.html) - Generate MD5, SHA-1, SHA-256, and SHA-512 hashes client-side.
 - [Hidden Tools](https://hiddentools-eight.vercel.app/) - Curated collection of unique online tools.
+- [Ibis](https://cartonpliant.github.io/ibis/) - Compose a one-page commercial offer in the browser. No account, free with watermark.
 - [Image Landscape Converter](https://image-landscape-converter.vercel.app/) - Rotate portrait photos to landscape orientation in the browser.
 - [ImgTools](https://imgtools.davrapps.dev) - Compress, resize, crop, convert, watermark, and remove backgrounds from images.
 - [JSON Crack](https://jsoncrack.com/editor) - Visualize and explore JSON data.


### PR DESCRIPTION
Adds [Ibis](https://cartonpliant.github.io/ibis/).

Ibis is a static, no-account composer for a one-page commercial offer (not invoices, not quotes). Free with watermark; Pro is 9 € for clean print, Markdown, and 5 layouts.

I am the maker. Live URL: https://cartonpliant.github.io/ibis/
Repo: https://github.com/CartonPliant/ibis