### PR TITLE
Add PX to REM Converter to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Password Generator](https://dailytoolkit.app/tools/password-generator) - Generate strong, random passwords with customizable length and character sets.
 - [Pixelate Image](https://www.pixelateimage.co/) - Pixelate images instantly in the browser.
 - [PWA Manifest Generator](https://www.simicart.com/manifest-generator.html/) - Generate a web app manifest with optimized icons.
+- [PX to REM Converter](https://www.devkitlab.com/en/tools/px-rem-converter/) - Convert px, rem, em, pt, and % against an adjustable root font-size, and generate fluid clamp() values for responsive type.
 - [README Generator](https://dailytoolkit.app/tools/readme-generator) - Build a formatted README.md by filling in project details.
 - [QR Code Generator](https://dailytoolkit.app/tools/qr-code-generator) - Create scannable QR codes from text, URLs, or contact info.
 - [Quick Image Kit](https://quickimagekit.com/) - Compress, resize, convert, crop images, and generate favicon packages in the browser.


### PR DESCRIPTION
Adds a px/rem converter to Utils, placed alphabetically between PWA Manifest Generator and README Generator.

Why it is not a duplicate: the list has no standalone px/rem tool at the moment - the only mention is inside the CSS Toolkit entry's feature list - and nothing in the README currently generates fluid clamp() values. It converts px, rem, em, pt and % against an adjustable root font-size, and builds the clamp() expression for type that scales between two viewport widths. Everything runs in the browser.

I kept the description to the unit conversion and clamp(), since Typescale in the Fonts section already covers modular type scales.

Disclosure: I built and maintain this. Happy to drop it if you feel Utils is already covered here.