### PR TITLE
Add BidiLens to Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Base64 Encoder/Decoder](https://optimize-overseas.github.io/autonomousbot/tools/base64.html) - Encode and decode Base64 strings client-side.
 - [Base64 Image](https://www.base64-image.de/) - Convert images to Base64 for use in HTML and CSS.
 - [BeginThings](https://beginthings.com) - 96+ free browser-based tools for freelancers including invoicing, time tracking, and QR codes.
+- [BidiLens](https://github.com/CodeinScrubs/BidiLens) - Tools and integration guides for rendering mixed RTL/LTR text in web interfaces.
 - [BulkPicTools](https://bulkpictools.com/) - Bulk image processor for compress, convert, resize, and crop — no upload required.
 - [Can I Email](https://www.caniemail.com/) - Support tables for HTML and CSS in email clients.
 - [Can I Use](https://caniuse.com/) - Up-to-date browser support tables for front-end web technologies.


### PR DESCRIPTION
## Summary

Adds [BidiLens](https://github.com/CodeinScrubs/BidiLens) to Utils, between BeginThings and BulkPicTools.

BidiLens provides tools and integration guides for mixed RTL/LTR user content, including Persian/English paragraphs in chat and Markdown interfaces. I maintain the project; this is a self-submission under the contribution guide's policy.

## Checks

- One factual sentence and an official, public source-repository link.
- Alphabetical placement in the existing Utils section.
- No existing BidiLens README entry or matching issue/PR found in the pre-submission search.
- `git diff --check` passes; only one README line changes.
