### PR TITLE
Add Responsive CSS Grid Generator to Layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [Flexplorer](https://bennettfeely.com/flexplorer/) - Interactive explorer for the CSS Flexible Box model.
 - [Grid Garden](https://cssgridgarden.com/) - Game for learning CSS grid layout.
 - [Layout Generator](https://layout.bradwoods.io/) - CSS Grid and Flexbox generator for UI layout components.
+- [Responsive CSS Grid Generator](https://cssgridgenerator.net/) - Draw a CSS Grid at each breakpoint and copy the CSS with media queries included.
 
 ## CSS loaders
 


### PR DESCRIPTION
Adds one tool to the **Layouts** section, placed alphabetically after `Layout Generator` per CONTRIBUTING.

Link: https://cssgridgenerator.net

Disclosure: I built it — happy for it to be judged on merit or closed.

The section already has `cssgrid-generator.netlify.app` and `layout.bradwoods.io`. The difference here is that you edit the grid **separately at each breakpoint** and the output includes the `@media` blocks, instead of a single static grid. It also has subgrid, masonry and container-query generators.

Free, no signup, no affiliate link. Description kept to one sentence and focused on what it does rather than marketing copy, as the guidelines ask.